### PR TITLE
Update floor plan survey bar chart

### DIFF
--- a/src/interfaces/profile/profileProps.ts
+++ b/src/interfaces/profile/profileProps.ts
@@ -30,5 +30,10 @@ interface FloorPlanDetails {
     sumMarket: number;
     unitCount: number;
     avgSqft: number;
+    unitStatuses: UnitStatusDetails;
+}
+
+interface UnitStatusDetails {
+    [key: string]: number;
 }
 

--- a/src/interfaces/propertyCards/property.ts
+++ b/src/interfaces/propertyCards/property.ts
@@ -25,5 +25,10 @@ interface FloorPlanDetails {
     sumMarket: number;
     unitCount: number;
     avgSqft: number;
+    unitStatuses: UnitStatusDetails;
+}
+
+interface UnitStatusDetails {
+    [key: string]: number;
 }
 

--- a/src/interfaces/propertyProfile/propertyProfileProps.ts
+++ b/src/interfaces/propertyProfile/propertyProfileProps.ts
@@ -18,7 +18,7 @@ type ISODateString = string;
 interface Vacancy {
     [key: string]: number;
 }
-type FloorPlans = Record<FloorPlanName, FloorPlanDetails>;
+export type FloorPlans = Record<FloorPlanName, FloorPlanDetails>;
 
 type FloorPlanName = string;
 
@@ -29,6 +29,11 @@ interface FloorPlanDetails {
     sumMarket: number;
     unitCount: number;
     avgSqft: number;
+    unitStatuses: UnitStatusDetails;
+}
+
+interface UnitStatusDetails {
+    [key: string]: number;
 }
 
 export interface LossToLease {

--- a/src/pages/building-summary-components/floorPlanAvgLease.tsx
+++ b/src/pages/building-summary-components/floorPlanAvgLease.tsx
@@ -1,20 +1,9 @@
 import Chart from 'react-apexcharts';
 import { useColorModeValue } from '@chakra-ui/react';
+import { FloorPlans } from '../../interfaces/propertyProfile/propertyProfileProps';
 
 interface FloorPlanAvgProps {
     floorplans: FloorPlans;
-}
-
-type FloorPlans = Record<FloorPlanName, FloorPlanDetails>;
-type FloorPlanName = string;
-
-interface FloorPlanDetails {
-    avgRent: number;
-    sumRent: number;
-    avgMarket: number;
-    sumMarket: number;
-    unitCount: number;
-    avgSqft: number;
 }
 
 export function FloorPlanAvgLease({ floorplans }: FloorPlanAvgProps) {

--- a/src/pages/building-summary-components/floorPlanCount.tsx
+++ b/src/pages/building-summary-components/floorPlanCount.tsx
@@ -5,20 +5,46 @@ import { FloorPlans } from '../../interfaces/propertyProfile/propertyProfileProp
 export function FloorPlanCount({ floorplans }: { floorplans: FloorPlans }) {
     const textColor = useColorModeValue("gray.800", 'white');
     const floorPlanNames = Object.keys(floorplans);
-    let statusTypes: string[] = [];
-    let statusCount: number[] = [];
-    console.log(floorplans)
-    const countValue = floorPlanNames.map(name => floorplans[name].unitCount)
 
-    const options ={
+    // Aggregate counts for each status type
+    const aggregatedStatusCounts: Record<string, number[]> = {};
+
+    floorPlanNames.forEach(name => {
+        const statuses = floorplans[name].unitStatuses;
+        Object.keys(statuses).forEach(statusType => {
+            if (!aggregatedStatusCounts[statusType]) {
+                aggregatedStatusCounts[statusType] = new Array(floorPlanNames.length).fill(0);
+            }
+            aggregatedStatusCounts[statusType][floorPlanNames.indexOf(name)] = statuses[statusType];
+        });
+    });
+
+    const series = Object.keys(aggregatedStatusCounts).map(statusType => ({
+        name: `${statusType.charAt(0).toUpperCase() + statusType.slice(1)}`,
+        data: aggregatedStatusCounts[statusType]
+    }));
+
+    const options = {
         chart: {
             id: 'floorplan-count-chart',
             type: 'bar',
-            foreColor: textColor
+            foreColor: textColor,
+            stacked: true,
+            toolbar: {
+                show: true,
+              },
         },
         plotOptions: {
             bar: {
-                horizontal: false
+                horizontal: false,
+                dataLabels: {
+                    total: {
+                        enabled: true,
+                        style: {
+                            color: textColor,
+                        }
+                    }
+                }
             }
         },
         xaxis: {
@@ -30,23 +56,18 @@ export function FloorPlanCount({ floorplans }: { floorplans: FloorPlans }) {
             }
         },
         dataLabels: {
-            enabled: true
+            enabled: true,
         },
         title: {
             text: 'Quantity of Units of Each Floor Plan',
             align: 'center'
         },
         tooltip: {
-            theme: useColorModeValue('light', 'dark')
+            theme: useColorModeValue('light', 'dark'),
+            shared: true,
+            intersect: false
         }
     } as any;
-
-    const series = [
-        {
-            name: 'Occupied Units',
-            data: countValue
-        }
-    ];
 
     return <Chart options={options} series={series} type="bar" height="300px"/>
 }

--- a/src/pages/building-summary-components/floorPlanCount.tsx
+++ b/src/pages/building-summary-components/floorPlanCount.tsx
@@ -1,20 +1,13 @@
 import Chart from 'react-apexcharts';
 import { useColorModeValue } from '@chakra-ui/react';
+import { FloorPlans } from '../../interfaces/propertyProfile/propertyProfileProps';
 
-interface FloorPlanDetails {
-    avgRent: number;
-    sumRent: number;
-    avgMarket: number;
-    sumMarket: number;
-    unitCount: number;
-    avgSqft: number;
-}
-type FloorPlanCategory = string;
-type LocalFloorPlans = Record<FloorPlanCategory, FloorPlanDetails>;
-
-export function FloorPlanCount({ floorplans }: { floorplans: LocalFloorPlans }) {
+export function FloorPlanCount({ floorplans }: { floorplans: FloorPlans }) {
     const textColor = useColorModeValue("gray.800", 'white');
     const floorPlanNames = Object.keys(floorplans);
+    let statusTypes: string[] = [];
+    let statusCount: number[] = [];
+    console.log(floorplans)
     const countValue = floorPlanNames.map(name => floorplans[name].unitCount)
 
     const options ={

--- a/src/pages/building-summary-components/recentSignedLeases.tsx
+++ b/src/pages/building-summary-components/recentSignedLeases.tsx
@@ -1,23 +1,12 @@
 import { RecentLeases } from "../../interfaces/propertyProfile/propertyProfileProps";
 import Chart from 'react-apexcharts';
 import { Heading, Text, useColorModeValue } from '@chakra-ui/react';
-
+import { FloorPlans } from '../../interfaces/propertyProfile/propertyProfileProps';
 
 interface RecentLeaseProps {
     recentLeases: RecentLeases;
-    floorplans: LocalFloorPlans;
+    floorplans: FloorPlans;
 }
-
-interface FloorPlanDetails {
-    avgRent: number;
-    sumRent: number;
-    avgMarket: number;
-    sumMarket: number;
-    unitCount: number;
-    avgSqft: number;
-}
-type FloorPlanCategory = string;
-type LocalFloorPlans = Record<FloorPlanCategory, FloorPlanDetails>;
 
 export function RecentSignedLeases({ recentLeases, floorplans }: RecentLeaseProps) {
     const textColor = useColorModeValue("gray.800", 'white');

--- a/src/pages/property-cards/propertyCards.tsx
+++ b/src/pages/property-cards/propertyCards.tsx
@@ -18,6 +18,8 @@ export function PropertyCards({ property, deleteProperty }: PropertyCardsProps) 
     const hoverColor = useColorModeValue("gray.300", "gray.900");
     const navigate = useNavigate()
 
+    console.log(floorplans)
+
     const formatDate = (isoString: string) => {
         const dateObj = new Date(isoString);
         const options: Intl.DateTimeFormatOptions = {

--- a/src/pages/property-cards/propertyCards.tsx
+++ b/src/pages/property-cards/propertyCards.tsx
@@ -18,8 +18,6 @@ export function PropertyCards({ property, deleteProperty }: PropertyCardsProps) 
     const hoverColor = useColorModeValue("gray.300", "gray.900");
     const navigate = useNavigate()
 
-    console.log(floorplans)
-
     const formatDate = (isoString: string) => {
         const dateObj = new Date(isoString);
         const options: Intl.DateTimeFormatOptions = {


### PR DESCRIPTION
Updated all interfaces relating to `floorplans` in the API data response object. 

Converted unit floorplan bar chart from just a unit count to now include unit count with unit statuses (vacant, occupied, etc) stacked on each other. 

closes #13 