### PR TITLE
Added 120, 150, and 180 days to recent leases per sqft comp

### DIFF
--- a/src/interfaces/propertyProfile/propertyProfileProps.ts
+++ b/src/interfaces/propertyProfile/propertyProfileProps.ts
@@ -45,6 +45,9 @@ export interface RecentLeases {
     [floorPlanName: string]: {
         recent_two: LeaseInfo;
         recent_leases: {
+            last_180_days: LeaseInfo;
+            last_150_days: LeaseInfo;
+            last_120_days: LeaseInfo;
             last_90_days: LeaseInfo;
             last_60_days: LeaseInfo;
             last_30_days: LeaseInfo;

--- a/src/pages/building-summary-components/recentSignedLeases.tsx
+++ b/src/pages/building-summary-components/recentSignedLeases.tsx
@@ -1,6 +1,6 @@
 import { RecentLeases } from "../../interfaces/propertyProfile/propertyProfileProps";
 import Chart from 'react-apexcharts';
-import { Heading, Text, useColorModeValue } from '@chakra-ui/react';
+import { Text, useColorModeValue } from '@chakra-ui/react';
 import { FloorPlans } from '../../interfaces/propertyProfile/propertyProfileProps';
 
 interface RecentLeaseProps {
@@ -12,12 +12,26 @@ export function RecentSignedLeases({ recentLeases, floorplans }: RecentLeaseProp
     const textColor = useColorModeValue("gray.800", 'white');
     const additionalInformationColor = useColorModeValue("#1A202C", "#A0AEC0");
 
+    let sqFt180Days: number = 0;
+    let avgRent180Days: number = 0;
+    let leaseCount180Days: number = 0;
+
+    let sqFt150Days: number = 0;
+    let avgRent150Days: number = 0;
+    let leaseCount150Days: number = 0;
+
+    let sqFt120Days: number = 0;
+    let avgRent120Days: number = 0;
+    let leaseCount120Days: number = 0;
+
     let sqFt90Days: number = 0;
     let avgRent90Days: number = 0;
     let leaseCount90Days: number = 0;
+
     let sqFt60Days: number = 0;
     let avgRent60Days: number = 0;
     let leaseCount60Days: number = 0;
+
     let sqFt30Days: number = 0;
     let avgRent30Days: number = 0;
     let leaseCount30Days: number = 0;
@@ -31,10 +45,28 @@ export function RecentSignedLeases({ recentLeases, floorplans }: RecentLeaseProp
         if (sqFtData > 0) {
             sqFtDataExists = true
         }
+
+        // Only add sqFt if the average rent is greater than 0
+        leaseCount180Days += rentData.recent_leases.last_180_days.count
+        avgRent180Days += rentData.recent_leases.last_180_days.average_rent
+        if (rentData.recent_leases.last_180_days.average_rent) {
+            sqFt180Days += sqFtData
+        }
+
+        leaseCount150Days += rentData.recent_leases.last_150_days.count
+        avgRent150Days += rentData.recent_leases.last_150_days.average_rent
+        if (rentData.recent_leases.last_150_days.average_rent) {
+            sqFt150Days += sqFtData
+        }
+
+        leaseCount120Days += rentData.recent_leases.last_120_days.count
+        avgRent120Days += rentData.recent_leases.last_120_days.average_rent
+        if (rentData.recent_leases.last_120_days.average_rent) {
+            sqFt120Days += sqFtData
+        }
         
         leaseCount90Days += rentData.recent_leases.last_90_days.count
         avgRent90Days += rentData.recent_leases.last_90_days.average_rent
-        // Only add sqFt if the average rent is greater than 0
         if (rentData.recent_leases.last_90_days.average_rent > 0) {
             sqFt90Days += sqFtData
         }
@@ -52,14 +84,17 @@ export function RecentSignedLeases({ recentLeases, floorplans }: RecentLeaseProp
         }
     }
 
-    const rent30DaysAvg: number = parseFloat((avgRent90Days / sqFt90Days).toFixed(2))
+    const rent180DaysAvg: number = parseFloat((avgRent180Days / sqFt180Days).toFixed(2))
+    const rent150DaysAvg: number = parseFloat((avgRent150Days / sqFt150Days).toFixed(2))
+    const rent120DaysAvg: number = parseFloat((avgRent120Days / sqFt120Days).toFixed(2))
+    const rent90DaysAvg: number = parseFloat((avgRent90Days / sqFt90Days).toFixed(2))
     const rent60DaysAvg: number = parseFloat((avgRent60Days / sqFt60Days).toFixed(2))
-    const rent90DaysAvg: number = parseFloat((avgRent30Days / sqFt30Days).toFixed(2))
+    const rent30DaysAvg: number = parseFloat((avgRent30Days / sqFt30Days).toFixed(2))
 
-    const labels: string[] = ['Previous 90 Days', 'Previous 60 Days', 'Previous 30 Days']
+    const labels: string[] = ['Previous 180 Days', 'Previous 150 Days', 'Previous 120 Days', 'Previous 90 Days', 'Previous 60 Days', 'Previous 30 Days']
     const series = [{
         name: "Avg Lease per SqFt ($)",
-        data: [rent90DaysAvg, rent60DaysAvg, rent30DaysAvg]
+        data: [rent180DaysAvg,rent150DaysAvg, rent120DaysAvg, rent90DaysAvg, rent60DaysAvg, rent30DaysAvg]
     }];
 
     const options = {
@@ -95,14 +130,31 @@ export function RecentSignedLeases({ recentLeases, floorplans }: RecentLeaseProp
         }
     } as any;
 
+    const leaseCount180DayNote = 
+    <>
+    <Text color={additionalInformationColor} size="sm">Leases signed in the last 180 days:<Text display='inline' ml={1} fontSize="md" color="teal.500" fontWeight='bold'>{leaseCount180Days}</Text></Text>
+    </>
+
+    const leaseCount150DayNote = 
+    <>
+    <Text color={additionalInformationColor} size="sm">Leases signed in the last 150 days:<Text display='inline' ml={1} fontSize="md" color="teal.500" fontWeight='bold'>{leaseCount150Days}</Text></Text>
+    </>
+
+    const leaseCount120DayNote = 
+    <>
+    <Text color={additionalInformationColor} size="sm">Leases signed in the last 120 days:<Text display='inline' ml={1} fontSize="md" color="teal.500" fontWeight='bold'>{leaseCount120Days}</Text></Text>
+    </>
+
     const leaseCount90DayNote = 
     <>
     <Text color={additionalInformationColor} size="sm">Leases signed in the last 90 days:<Text display='inline' ml={1} fontSize="md" color="teal.500" fontWeight='bold'>{leaseCount90Days}</Text></Text>
     </>
+
     const leaseCount60DayNote = 
     <>
     <Text color={additionalInformationColor} size="sm">Leases signed in the last 60 days:<Text display='inline' ml={1} fontSize="md" color="teal.500" fontWeight='bold'>{leaseCount60Days}</Text></Text>
     </>
+
     const leaseCount30DayNote = 
     <>
     <Text color={additionalInformationColor} size="sm">Leases signed in the last 30 days:<Text display='inline' ml={1} fontSize="md" color="teal.500" fontWeight='bold'>{leaseCount30Days}</Text></Text>
@@ -117,6 +169,9 @@ export function RecentSignedLeases({ recentLeases, floorplans }: RecentLeaseProp
     return (
         <>
         {sqFtDataExists ? chart : noSqFtDataResponse}
+        {leaseCount180Days > 0 ? leaseCount180DayNote : ''}
+        {leaseCount150Days > 0 ? leaseCount150DayNote : ''}
+        {leaseCount120Days > 0 ? leaseCount120DayNote : ''}
         {leaseCount90Days > 0 ? leaseCount90DayNote : ''}
         {leaseCount60Days > 0 ? leaseCount60DayNote : ''}
         {leaseCount30Days > 0 ? leaseCount30DayNote : ''}


### PR DESCRIPTION
Added additional data points to the line chart `recent leases signed per sqft`.

Closes #15 